### PR TITLE
[9] add application_name, for ips monitoring

### DIFF
--- a/gui/irodsTicketLogin.py
+++ b/gui/irodsTicketLogin.py
@@ -17,6 +17,8 @@ class irodsTicketLogin():
         self.coll = None
         self.widget = widget
 
+        self.this_application = 'iBridgesGui'
+
         # QTreeViews
         self.dirmodel = checkableFsTreeModel(self.widget.localFsTreeView)
         self.widget.localFsTreeView.setModel(self.dirmodel)
@@ -48,7 +50,7 @@ class irodsTicketLogin():
         token = self.widget.ticketEdit.text().strip()
 
         try:
-            self.ic = irodsConnectorAnonymous(host, token, path)
+            self.ic = irodsConnectorAnonymous(host, token, path, application_name=self.this_application)
             self.coll = self.ic.getData()
             self.loadTable()
             self.enableButtons(True)

--- a/irods-iBridgesGui.py
+++ b/irods-iBridgesGui.py
@@ -32,7 +32,7 @@ class irodsLogin(QDialog):
         super(irodsLogin, self).__init__()
         loadUi("gui/ui-files/irodsLogin.ui", self)
         ensure_dir(os.path.expanduser('~') + os.sep + ".irods")
-        
+        self.this_application = 'iBridgesGui'
         self.irodsEnvPath = os.path.expanduser('~') + os.sep + ".irods"
         setup_logger(self.irodsEnvPath, "iBridgesGui")
         if not os.path.isdir(self.irodsEnvPath):
@@ -53,9 +53,9 @@ class irodsLogin(QDialog):
     
     def __irodsLogin(self, envFile, password, cipher):
         if self.icommands:
-            ic = irodsConnectorIcommands(cipher.decrypt(password).decode())
+            ic = irodsConnectorIcommands(cipher.decrypt(password).decode(), application_name=self.this_application)
         else:
-            ic = irodsConnector(envFile, cipher.decrypt(password).decode())
+            ic = irodsConnector(envFile, cipher.decrypt(password).decode(), application_name=self.this_application)
         return ic
 
     def __resetErrorLabelsAndMouse(self):

--- a/utils/irodsConnector.py
+++ b/utils/irodsConnector.py
@@ -30,7 +30,7 @@ BLUE = '\x1b[1;34m'
 
 
 class irodsConnector():
-    def __init__(self, envFile, password=""):
+    def __init__(self, envFile, password="", application_name=None):
         """
         iRODS authentication with python.
         Input:
@@ -56,7 +56,7 @@ class irodsConnector():
                 raise CAT_INVALID_AUTHENTICATION("No password provided.")
 
             else:
-                self.session = iRODSSession(**ienv, password=password)
+                self.session = iRODSSession(**ienv, password=password, application_name=application_name)
                 testcoll = self.session.collections.get(
                         "/"+self.session.zone+"/home")
         except PlainTextPAMPasswordError:
@@ -71,7 +71,7 @@ class irodsConnector():
                             'encryption_salt_size': 8,
                             'ssl_context': ssl_context}
                 self.session = iRODSSession(
-                                **ienv, password=password, **ssl_settings)
+                                **ienv, password=password, application_name=application_name, **ssl_settings)
             except:
                 raise
 

--- a/utils/irodsConnectorAnonymous.py
+++ b/utils/irodsConnectorAnonymous.py
@@ -23,7 +23,7 @@ BLUE = '\x1b[1;34m'
 
 
 class irodsConnectorAnonymous(irodsConnector):
-    def __init__(self, host, ticket, path):
+    def __init__(self, host, ticket, path, application_name=None):
         """
         iRODS anonymous login.
         Input:
@@ -46,7 +46,8 @@ class irodsConnectorAnonymous(irodsConnector):
                                     password='',
                                     zone=zone,
                                     port=1247,
-                                    host=host)
+                                    host=host,
+                                    application_name=application_name)
         self.token = ticket
         self.path = path
 

--- a/utils/irodsConnectorIcommands.py
+++ b/utils/irodsConnectorIcommands.py
@@ -19,7 +19,7 @@ BLUE = '\x1b[1;34m'
 
 
 class irodsConnectorIcommands(irodsConnector):
-    def __init__(self, password=''):
+    def __init__(self, password='', application_name=None):
         """
         iRODS authentication.
         Input:
@@ -58,7 +58,7 @@ class irodsConnectorIcommands(irodsConnector):
             if errLogin != b'':
                 logging.info("AUTHENTICATION ERROR: Wrong iRODS password provided.")
                 raise ConnectionRefusedError('Wrong iRODS password provided.')
-            self.session = iRODSSession(irods_env_file=envFile)
+            self.session = iRODSSession(irods_env_file=envFile, application_name=application_name)
         else:
             logging.info("Password cached, trying ils:")
             p = Popen(['ils'], stdout=PIPE, stdin=PIPE, stderr=PIPE, shell=True)
@@ -71,7 +71,7 @@ class irodsConnectorIcommands(irodsConnector):
                 if errLogin != b'':
                     logging.info('AUTHENTICATION ERROR: Wrong iRODS password provided.')
                     raise ConnectionRefusedError('Wrong iRODS password provided.')
-            self.session = iRODSSession(irods_env_file=envFile)
+            self.session = iRODSSession(irods_env_file=envFile, application_name=application_name)
         try:
             colls = self.session.collections.get("/" + self.session.zone + "/home").subcollections
         except CollectionDoesNotExist:


### PR DESCRIPTION
There is probably a better place to declare the application name only once.   I had to declare it twice in this PR.

I then use it in the Connection to iRODS.  This makes the application name appear in the `ips` output for the iRODS Zone.

I believe the work done in f4afed010b9e35ae50eba025beecb8d75d90f008 via `setproctitle` only sets the name for the local operating system.