### PR TITLE
[91] Unify logging initialization

### DIFF
--- a/iBridgesCli.py
+++ b/iBridgesCli.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from irods.exception import CollectionDoesNotExist, SYS_INVALID_INPUT_PARAM
 import irodsConnector.keywords as kw
 from irodsConnector.manager import IrodsConnector
-from utils.utils import init_logger, get_local_size
+from utils.utils import get_local_size, init_logger, set_log_level
 from utils.context import Context
 from utils.elab_plugin import ElabPlugin
 
@@ -117,6 +117,7 @@ class IBridgesCli:                          # pylint: disable=too-many-instance-
         self.operation = operation
         self.plugins = self._cleanup_plugins(plugins)
         init_logger(logdir_path, "iBridgesCli")
+        set_log_level()
         self._run()
 
     @classmethod


### PR DESCRIPTION
I would like to unify the use of the logger initialization.  The tricky part is to initialize logging with the default logging level as soon as possible and setting the user's preferred logging level _after_ the **Context** is initialized.  Doing that at the same time is likely to cause issues, one of which is initializing the context _before_ intended.

As of the commit associated with Issue #91, there are two copies of the **init_logger()** function.  I have updated this a bit in PR #97 by moving **set_log_level()** to `utils/utils.py`, but I would like to merge the functionality of **init_logger()** as well so there is only one copy.  This PR updates `iBridges.py` and `iBridgesCli.py` to use the same functions, but in slightly different ways.

The only conceptual problem I'm having in `iBridgesCli.py` is that **Context** is formally meant to be initialized in **connect_irods()**, but the logger is initialized in the constructor.  Setting of the log level from the configuration was first done via **utils.utils.init_logger()**, but now via **utils.utils.set_log_level()**.  This is done to meet the condition mentioned at the top.

Questions:

1. Why is **connect_irods()** a class method?  It is not used anywhere else I can see except as a normal method?
2. Can the **Context** initialization be moved up to the constructor?
3. Better yet, could perhaps a **main()** function can be used for argument parsing/running and the logging/**Context** be initialized there instead?  That would be more in line with how `iBridges.py` is doing it.