### PR TITLE
bugfix meta class not instantiated in manager

### DIFF
--- a/irodsConnector/manager.py
+++ b/irodsConnector/manager.py
@@ -165,7 +165,7 @@ class IrodsConnector(object):
     @property
     def meta(self) -> meta.Meta:
         if self._meta is None:
-            meta.Meta()
+            self._meta = meta.Meta()
         return self._meta
 
     @property


### PR DESCRIPTION
Somehow these things always happen during demo's. 
While trying some things the metdata operations all failed. 
I am happy to say it was a small problem, instead of making an issue and putting it on the todo list I fixed it right away. 

