### PR TITLE
[121] Adjust Context workflow

### DIFF
--- a/gui/irodsTreeView.py
+++ b/gui/irodsTreeView.py
@@ -8,7 +8,7 @@ import collections
 import logging
 import os
 
-import irods
+import irods.exception
 import PyQt6
 import PyQt6.QtCore
 import PyQt6.QtGui
@@ -25,8 +25,7 @@ ACCESS_NAMES = [
 ]
 
 
-class IrodsModel(PyQt6.QtGui.QStandardItemModel,
-                 utils.context.ContextContainer):
+class IrodsModel(PyQt6.QtGui.QStandardItemModel):
     """Model for an iRODS tree view.
 
     """
@@ -49,6 +48,7 @@ class IrodsModel(PyQt6.QtGui.QStandardItemModel,
         """
         super().__init__(parent)
         self.tree_view = tree_view
+        self.conn = utils.context.Context().irods_connector
         try:
             self.user_groups = self.conn.get_user_info()[1]
         except irods.exception.NetworkException:
@@ -174,7 +174,8 @@ class IrodsModel(PyQt6.QtGui.QStandardItemModel,
             parent.appendRow(row)
             nodes_in_tree[irods_id] = parent.child(parent.rowCount() - 1)
 
-    def delete_subtree(self, tree_item):
+    @staticmethod
+    def delete_subtree(tree_item):
         """Delete subtree?
 
         Parameters
@@ -246,7 +247,8 @@ class IrodsModel(PyQt6.QtGui.QStandardItemModel,
             data.append(row)
         return data
 
-    def add_subtree(self, tree_item, tree_level, irods_fs_subtree_data):
+    @staticmethod
+    def add_subtree(tree_item, tree_level, irods_fs_subtree_data):
         """Grow tree_view from tree_item
 
         Parameters

--- a/iBridges.py
+++ b/iBridges.py
@@ -125,9 +125,6 @@ class IrodsLoginWindow(PyQt6.QtWidgets.QDialog,
         """Check connectivity and log in to iRODS handling common errors.
 
         """
-        # Replacement connector (required for new sessions)
-        if not self.context.irods_connector:
-            logging.debug('Setting new instance of the IrodsConnector')
         irods_env_file = self.irods_path.joinpath(self.envbox.currentText())
         self.context.irods_env_file = irods_env_file
         logging.debug('IRODS ENVIRONMENT FILE SET: %s', irods_env_file.name)
@@ -227,11 +224,10 @@ def main():
     utils.utils.init_logger(THIS_APPLICATION)
     # Singleton Context
     context = utils.context.Context()
-    context.irods_connector = irodsConnector.manager.IrodsConnector()
-    context.application_name = THIS_APPLICATION
     # Context is required to get the log_level from the configuration.
     # Here, it is taken from the configuration if not specified.
     utils.utils.set_log_level()
+    context.application_name = THIS_APPLICATION
     context.irods_connector = irodsConnector.manager.IrodsConnector()
     setproctitle.setproctitle(context.application_name)
     login_window = IrodsLoginWindow()

--- a/irodsConnector/manager.py
+++ b/irodsConnector/manager.py
@@ -197,9 +197,8 @@ class IrodsConnector():
 
     @session.deleter
     def session(self):
-        if self._session:
-            del self._session
-            self._session = None
+        del self._session
+        self._session = None
 
     @property
     def tickets(self) -> tickets.Tickets:

--- a/utils/context.py
+++ b/utils/context.py
@@ -229,6 +229,7 @@ class Context:
         """Reset existing instances of dynamic class members
 
         """
+        self.irods_connector.reset()
         if self.ibridges_configuration:
             self.ibridges_configuration.reset()
             filepath = path.LocalPath(self.ibridges_conf_file).expanduser()
@@ -237,8 +238,6 @@ class Context:
             self.irods_environment.reset()
             filepath = path.LocalPath(self.irods_env_file).expanduser()
             self.irods_environment.filepath = filepath
-        if self.irods_connector:
-            self.irods_environment.reset()
 
 
 def is_complete(conf_dict: dict, mandatory: list, conf_type: str) -> bool:
@@ -278,8 +277,8 @@ class ContextContainer:
     context = Context()
 
     def __init__(self):
-        logging.info("WARNING: ContextContainer is deprecated.")
-        print("WARNING: ContextContainer is deprecated.")
+        logging.debug('ContextContainer inherited by: %s', type(self).__name__)
+        logging.debug('ContextContainer is deprecated!')
 
     @property
     def conf(self) -> dict:


### PR DESCRIPTION
- reset irods_connector instead of deleting it
- use debug level logging for deprecation warnings
  - they are only for developers
- remove redundant code snippets
- remove ContextContainer from IrodsModel
  - it was the only one loading upon startup