### PR TITLE
CLI plugins compatible with Python 3.8

### DIFF
--- a/iBridgesCli.py
+++ b/iBridgesCli.py
@@ -7,6 +7,7 @@ Implemented for:
     Storage types:
         iRODS
 """
+from __future__ import annotations
 import argparse
 import logging
 import configparser


### PR DESCRIPTION
Added  `from __future__ import annotations` so `dict` is recognized as a valid type in Python 3.8.