### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 
 dependencies = [
     "PyQt6>=6.4.2",
-    "ibridges>=1.0.0",
+    "ibridges==1.0.0",
     "setproctitle==1.3.3",
     "importlib-resources;python_version<='3.10'",
 ]


### PR DESCRIPTION
New version of iBridges crashes the GUI. Quickfix: fix to ibridges 1.0.0 inpyproject toml and release.