### PR TITLE
add last upload and download location to config

### DIFF
--- a/ibridgesgui/config.py
+++ b/ibridgesgui/config.py
@@ -96,12 +96,14 @@ def get_last_ienv_name() -> Union[None, str]:
         return config.get("gui_last_env")
     return None
 
-def get_last_ienv_path() ->  Union[None, str]:
+
+def get_last_ienv_path() -> Union[None, str]:
     """Retrieve the last successfully used environment file."""
     name = get_last_ienv_name()
     if name:
         return name.split(" - ")[1]
     return None
+
 
 def set_last_ienv(ienv: str):
     """Save the last used environment path to the config file.
@@ -171,22 +173,30 @@ def config_remove_tab(tab_provider: object):
 
 
 def config_set_last_upload_path(path: Path):
+    """Store the folder of the upload dialog."""
     config = _get_config()
     config["last_upload_path"] = str(path)
     _save_config(config)
 
+
 def config_get_last_upload_path():
+    """Get the last used upload location."""
     config = _get_config()
     return config.get("last_upload_path", None)
 
+
 def config_set_last_download_path(path: Path):
+    """Store the folder of download dialog."""
     config = _get_config()
     config["last_download_path"] = str(path)
     _save_config(config)
 
+
 def config_get_last_download_path():
+    """Get the lats used download location."""
     config = _get_config()
     return config.get("last_download_path", None)
+
 
 def get_tabs() -> list:
     """Get list of previously chosen tird party tab providers."""

--- a/ibridgesgui/config.py
+++ b/ibridgesgui/config.py
@@ -170,6 +170,24 @@ def config_remove_tab(tab_provider: object):
             _save_config(config)
 
 
+def config_set_last_upload_path(path: Path):
+    config = _get_config()
+    config["last_upload_path"] = str(path)
+    _save_config(config)
+
+def config_get_last_upload_path():
+    config = _get_config()
+    return config.get("last_upload_path", None)
+
+def config_set_last_download_path(path: Path):
+    config = _get_config()
+    config["last_download_path"] = str(path)
+    _save_config(config)
+
+def config_get_last_download_path():
+    config = _get_config()
+    return config.get("last_download_path", None)
+
 def get_tabs() -> list:
     """Get list of previously chosen tird party tab providers."""
     config = _get_config()

--- a/ibridgesgui/popup_widgets.py
+++ b/ibridgesgui/popup_widgets.py
@@ -15,6 +15,7 @@ from ibridges.exception import DataObjectExistsError
 from ibridges.util import find_environment_provider, get_environment_providers
 
 from ibridgesgui.config import _read_json, check_irods_config, get_last_ienv_path, save_irods_config
+from ibridgesgui.config import config_set_last_upload_path, config_set_last_download_path, config_get_last_upload_path, config_get_last_download_path
 from ibridgesgui.gui_utils import UI_FILE_DIR, combine_operations, load_ui, populate_textfield
 from ibridgesgui.threads import TransferDataThread
 from ibridgesgui.ui_files.configCheck import Ui_configCheck
@@ -322,22 +323,32 @@ class UploadData(PySide6.QtWidgets.QDialog, Ui_uploadData):
 
     def select_file(self):
         """Open file selector."""
+        last_upload_path = config_get_last_upload_path()
+        if not last_upload_path:
+            last_upload_path = Path("~").expanduser()
         select_file = PySide6.QtWidgets.QFileDialog.getOpenFileName(
-            self, "Open File", dir=str(Path("~").expanduser())
+            self, "Open File", dir=str(last_upload_path)
         )
         path = self._fs_select(select_file)
         if path is None or str(path) == "." or path in self.sources_list.toPlainText():
             return
+        print(path)
+        config_set_last_upload_path(Path(path).parent)
         self.sources_list.append(path)
 
     def select_folder(self):
         """Open folder selctor."""
+        last_upload_path = config_get_last_upload_path()
+        if not last_upload_path:
+            last_upload_path = Path("~").expanduser()
         select_dir = PySide6.QtWidgets.QFileDialog.getExistingDirectory(
-            self, "Select Directory", dir=str(Path("~").expanduser())
+            self, "Select Directory", dir=str(last_upload_path)
         )
         path = self._fs_select(select_dir)
         if path is None or str(path) == "." or path in self.sources_list.toPlainText():
             return
+        print(path)
+        config_set_last_upload_path(path)
         self.sources_list.append(path)
 
     def _get_upload_params(self):
@@ -490,14 +501,18 @@ class DownloadData(PySide6.QtWidgets.QDialog, Ui_downloadData):
     def select_folder(self):
         """Select the download destination."""
         self.error_label.clear()
+        last_download_path = config_get_last_download_path()
+        if not last_download_path:
+            last_download_path = Path("~").expanduser()
         select_dir = Path(
             PySide6.QtWidgets.QFileDialog.getExistingDirectory(
-                self, "Select Directory", dir=str(Path("~").expanduser())
+                self, "Select Directory", dir=str()
             )
         )
         if str(select_dir) == "" or str(select_dir) == ".":
             return
         self.destination_label.setText(str(select_dir))
+        config_set_last_download_path(last_download_path)
 
     def _get_download_params(self):
         """Retrieve and check all parameters for the dpwnload."""

--- a/ibridgesgui/popup_widgets.py
+++ b/ibridgesgui/popup_widgets.py
@@ -14,8 +14,16 @@ from ibridges import IrodsPath, download, upload
 from ibridges.exception import DataObjectExistsError
 from ibridges.util import find_environment_provider, get_environment_providers
 
-from ibridgesgui.config import _read_json, check_irods_config, get_last_ienv_path, save_irods_config
-from ibridgesgui.config import config_set_last_upload_path, config_set_last_download_path, config_get_last_upload_path, config_get_last_download_path
+from ibridgesgui.config import (
+    _read_json,
+    check_irods_config,
+    config_get_last_download_path,
+    config_get_last_upload_path,
+    config_set_last_download_path,
+    config_set_last_upload_path,
+    get_last_ienv_path,
+    save_irods_config,
+)
 from ibridgesgui.gui_utils import UI_FILE_DIR, combine_operations, load_ui, populate_textfield
 from ibridgesgui.threads import TransferDataThread
 from ibridgesgui.ui_files.configCheck import Ui_configCheck
@@ -505,9 +513,7 @@ class DownloadData(PySide6.QtWidgets.QDialog, Ui_downloadData):
         if not last_download_path:
             last_download_path = Path("~").expanduser()
         select_dir = Path(
-            PySide6.QtWidgets.QFileDialog.getExistingDirectory(
-                self, "Select Directory", dir=str()
-            )
+            PySide6.QtWidgets.QFileDialog.getExistingDirectory(self, "Select Directory", dir=str())
         )
         if str(select_dir) == "" or str(select_dir) == ".":
             return


### PR DESCRIPTION
Add the keywords "last_upload_path" and "last_download_path" to the config. 
When the Upload and Download popup widgets are opened the file selection navigates to those paths rather than to the home. 
If the new config items are not set, the selection will start at the home directory.