### PR TITLE
add context column to resc table

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ Please note, that this feature is still in experimental state.
 
 ### Prebuilt executables
 Go to the [Releases page](https://github.com/iBridges-for-iRODS/iBridges-GUI/releases). In the latest releases you will find three zip-files, these contain the prebuilt application.
-Download the respective zip-file for your system and unpack it. In the unpacked folder there is a file `ibridges_gui.[exe, sh]`
-For Windows simply click on the exe-file, for Mac and Linux open the file with a shell `bash ./ibridges_gui.sh`.
+Download the respective zip-file for your system and unpack it. In the unpacked folder there is a file `ibridges_gui.[exe, bin]`
+For Windows simply click on the exe-file, for Mac and Linux open the file with a shell `bash ./ibridges_gui.bin`.
 
 
 ### Building Executables

--- a/ibridgesgui/info.py
+++ b/ibridgesgui/info.py
@@ -46,7 +46,7 @@ class Info(PySide6.QtWidgets.QWidget, Ui_tabInfo):
         self.version_label.setText(".".join((str(num) for num in self.session.server_version)))
         # irods resources
         resc_info = Resources(self.session).root_resources
-        populate_table(self.resc_table, len(resc_info[0]), resc_info)
+        populate_table(self.resc_table, len(resc_info), resc_info)
         header = self.resc_table.horizontalHeader()
         for col in range(header.count()):
             header.setSectionResizeMode(col, PySide6.QtWidgets.QHeaderView.ResizeToContents)

--- a/ibridgesgui/ui_files/tabInfo.py
+++ b/ibridgesgui/ui_files/tabInfo.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'tabInfo.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.8.1
+## Created by: Qt User Interface Compiler version 6.10.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -167,14 +167,16 @@ class Ui_tabInfo(object):
         self.gridLayout.addWidget(self.label_8, 8, 0, 1, 1)
 
         self.resc_table = QTableWidget(tabInfo)
-        if (self.resc_table.columnCount() < 3):
-            self.resc_table.setColumnCount(3)
+        if (self.resc_table.columnCount() < 4):
+            self.resc_table.setColumnCount(4)
         __qtablewidgetitem = QTableWidgetItem()
         self.resc_table.setHorizontalHeaderItem(0, __qtablewidgetitem)
         __qtablewidgetitem1 = QTableWidgetItem()
         self.resc_table.setHorizontalHeaderItem(1, __qtablewidgetitem1)
         __qtablewidgetitem2 = QTableWidgetItem()
         self.resc_table.setHorizontalHeaderItem(2, __qtablewidgetitem2)
+        __qtablewidgetitem3 = QTableWidgetItem()
+        self.resc_table.setHorizontalHeaderItem(3, __qtablewidgetitem3)
         self.resc_table.setObjectName(u"resc_table")
         self.resc_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.resc_table.setSelectionMode(QAbstractItemView.NoSelection)
@@ -255,6 +257,8 @@ class Ui_tabInfo(object):
         ___qtablewidgetitem1.setText(QCoreApplication.translate("tabInfo", u"Status", None));
         ___qtablewidgetitem2 = self.resc_table.horizontalHeaderItem(2)
         ___qtablewidgetitem2.setText(QCoreApplication.translate("tabInfo", u"Free Space", None));
+        ___qtablewidgetitem3 = self.resc_table.horizontalHeaderItem(3)
+        ___qtablewidgetitem3.setText(QCoreApplication.translate("tabInfo", u"Context", None));
         self.label_3.setText(QCoreApplication.translate("tabInfo", u"Zone", None))
         self.label_9.setText(QCoreApplication.translate("tabInfo", u"Resources", None))
         self.version_label.setText("")

--- a/ibridgesgui/ui_files/tabInfo.ui
+++ b/ibridgesgui/ui_files/tabInfo.ui
@@ -279,6 +279,11 @@ QTextEdit, QTableWidget
          <string>Free Space</string>
         </property>
        </column>
+       <column>
+        <property name="text">
+         <string>Context</string>
+        </property>
+       </column>
       </widget>
      </item>
      <item row="7" column="2">


### PR DESCRIPTION
The default number of rows is 4 since pyside fills up the empty space that the widget has with them. I added a fourth column. 