### PR TITLE
Expose ibridges-gui entrypoint in pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,19 @@ You can find the latest release [here](https://github.com/iBridges-for-iRODS/iBr
 The build was done using the latest version on an x64 architecture.
 
 ## Installation
-- The python package 
+- Install the python package into its own virtual environment (recommended):
+
+  ```bash
+  uv tool install ibridgesgui # installs for your user by default; see uv tool options for how to install for all users on the system
+  ```
+
+  OR
+
+  ```bash
+  pipx install ibridgesgui
+  ```
+
+- Install the python package in the current virtual environment (or system-wide):
 
   ```bash
   pip install ibridgesgui
@@ -60,11 +72,18 @@ The build was done using the latest version on an x64 architecture.
   ```
   
 ## Start the GUI
-- From a pip python package
+- For normal users
 
   ```bash
-  ibridges gui
+  ibridges-gui
   ```
+
+  OR
+
+  ```bash
+  ibridges gui # only works if the 'ibridges' cli tool is also available
+  ```
+
 - From code (for developers)
 
   ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ all = [
     "ibridgesgui[test,deploy]",
 ]
 
+[project.scripts]
+ibridges-gui = "ibridgesgui.__main__:main"
+
 [tool.setuptools]
 packages = ["ibridgesgui"]
 


### PR DESCRIPTION
This is so users can `uv tool install ibridgesgui`. This (or `pipx install` if you don't want `uv`) is current best practice for installing executable python apps: `uv tool` ensures the app is isolated in its own virtual environment and the entrypoints become available on your PATH (no matter what venv you are in). You can also use `uv tool` to install an application for all users on the system.

You can test this already with `uv tool install git+https://github.com/dometto/iBridges-GUI.git@add_entrypoint`